### PR TITLE
prevent caching of cors headers

### DIFF
--- a/http/cors.go
+++ b/http/cors.go
@@ -9,6 +9,7 @@ func (h *Handler) addCORSHeaders(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Vary", "Origin")
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 }


### PR DESCRIPTION
When visiting siteB.com after visiting siteA.com which also imports `/clientErrorsReporter.min.js` i get CORS policy violation, because file with header `Access-Control-Allow-Origin: siteA.com` is already in cache